### PR TITLE
add primary key on (user_id, date)

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -16,7 +16,7 @@ CREATE TABLE worked_hours (
   date DATE NOT NULL,
   hours NUMERIC(4,2) NOT NULL CHECK (hours > 0 AND hours <= 24),
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-  PRIMARY KEY (user_id, date)
+  PRIMARY KEY (user_id, date),
   CONSTRAINT fk_users
     FOREIGN KEY(user_id)
     REFERENCES users(id)


### PR DESCRIPTION
This comes down to design a bit, but you may want the primary key on (user_id, date). 

Otherwise, you could add two new worked_hours rows for the same user/date whose sum is >24 hours and that does not make logical sense.