### PR TITLE
[adhoc] rename database container and worked_hours table

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   db:
-    container_name: postgres-db
+    container_name: take-home-db
     image: postgres:13-alpine
     restart: always
     ports:


### PR DESCRIPTION
This resolves this error for me:
```
Creating postgres-db ... error

ERROR: for postgres-db  Cannot create container for service db: Conflict. The container name "/postgres-db" is already in use by container "cd4b4f76e0d5eea58e3d8beed5d92821e561d309fc34622a1585c4d1233f6707". You have to remove (or rename) that container to be able to reuse that name.

ERROR: for db  Cannot create container for service db: Conflict. The container name "/postgres-db" is already in use by container "cd4b4f76e0d5eea58e3d8beed5d92821e561d309fc34622a1585c4d1233f6707". You have to remove (or rename) that container to be able to reuse that name.
ERROR: Encountered errors while bringing up the project.
```

renaming worked_hours for grammatical clarity.

You can take or leave this PR, I just wanted to provide this as a suggestion